### PR TITLE
Fix checks for multi-value select fields in `have_form_field`

### DIFF
--- a/lib/hyrax/spec/matchers/have_form_field.rb
+++ b/lib/hyrax/spec/matchers/have_form_field.rb
@@ -14,7 +14,8 @@ RSpec::Matchers.define :have_form_field do |name|
                 when 'input'
                   @field.attributes['class'].value.include? 'multi_value'
                 when 'select'
-                  @field.attributes['multiple']
+                  @field.attributes['multiple'] ||
+                    @field.attributes['class'].value.include? 'multi_value'
                 end
 
     if label


### PR DESCRIPTION
Some multi_value form select fields were treated as single value. multi_value
status for select fields can be indicated *either* by the presence of the
`multiple` attribute, or by the presence of the class `multi_value`. We
previously detected only the former, treating some multi- fields as
single-valued.