### PR TITLE
Add `have_show_field` matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Hyrax::Spec
 
 Shared examples and smoke tests for [Hyrax](https://github.com/samvera/hyrax) applications.
 
+## `RSpec` Matchers
+
+`Hyrax::Spec::Matchers` includes a variety of custom matchers for use with RSpec. These matchers can be included in
+your suite in batch  by adding `require 'hyrax/spec/matchers'` to your test helper (usually `spec/rails_helper.rb`),
+or individually requiring them (as in `require 'hyrax/spec/matchers/have_form_field'`).
+
+**Note**: documentation on matchers remains somewhat thin. The best current reference is their use in [`mahonia`](https://github.com/curationexperts/mahonia/), an ETD repository.
+
 ## `FactoryBot` Build Strategies for Hyrax
 
 If your test suite uses `FactoryBot` (formerly `FactoryGirl`) to create test objects, `Hyrax::Spec` provides useful

--- a/lib/hyrax/spec/matchers.rb
+++ b/lib/hyrax/spec/matchers.rb
@@ -8,6 +8,7 @@ module Myrax
       require 'hyrax/spec/matchers/act'
       require 'hyrax/spec/matchers/have_editable_property'
       require 'hyrax/spec/matchers/have_form_field'
+      require 'hyrax/spec/matchers/have_show_field'
       require 'hyrax/spec/matchers/list_index_fields'
     end
   end

--- a/lib/hyrax/spec/matchers/have_show_field.rb
+++ b/lib/hyrax/spec/matchers/have_show_field.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+RSpec::Matchers.define :have_show_field do |name|
+  match do |rendered_view|
+    @displayed_fields = rendered_view.find_css("li.#{name}")
+
+    @exists         = !@displayed_fields.empty?
+    @extra_actual   = []
+    @extra_expected = []
+
+    return false unless @exists
+
+    if @values
+      displayed_values = @displayed_fields.map(&:text)
+      @extra_actual    = displayed_values - @values
+      @extra_expected  = @values - displayed_values
+    end
+
+    @label_exists = rendered_view.all(:xpath, "//th[.//text()=\"#{@label}\"]").any? if @label
+
+    @exists && @extra_actual.empty? && @extra_expected.empty? && (!@label || @label_exists)
+  end
+
+  chain :and_label,  :label
+  chain :with_label, :label
+
+  chain :and_values do |*values|
+    @values = values
+  end
+
+  chain :with_values do |*values|
+    @values = values
+  end
+
+  failure_message do |rendered_view|
+    msg = "expected #{rendered_view} to have field #{name}"
+    msg += " with values #{@values}"                               if     @values
+    msg += ' but no field was present.'                            unless @exists
+    msg += "\n\t#{@extra_actual} were found in the view."          unless @extra_actual.empty?
+    msg += "\n\t#{@extra_expected} were expected but not present." unless @extra_expected.empty?
+    msg
+  end
+end


### PR DESCRIPTION
Ports the `have_show_field` matcher from `mahonia`. This is copied in exactly
from
https://github.com/curationexperts/mahonia/blob/e90ed2151ec7dc06fd9306cdd5cc50ba5be6ef94/spec/support/matchers/have_show_field.rb