### PR TITLE
Add YARD documentation badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Hyrax::Spec
 
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/gems/hyrax-spec)
 
-Shared examples and smoke tests for [Hyrax](https://github.com/samvera/hyrax) applications.
+Shared examples and smoke tests for [Hyrax](https://github.com/samvera/hyrax) applications. See the
+[documentation](http://www.rubydoc.info/gems/hyrax-spec) for more information.
 
 ## `FactoryBot` Build Strategies for Hyrax
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Hyrax::Spec
 ===========
 
+[![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/gems/hyrax-spec)
+
 Shared examples and smoke tests for [Hyrax](https://github.com/samvera/hyrax) applications.
 
 ## `FactoryBot` Build Strategies for Hyrax


### PR DESCRIPTION
This badge is lifted from https://github.com/docmeta/rubydoc.info/issues/61.